### PR TITLE
feat: add nvidia kmod builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,13 +8,17 @@ ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 
 COPY build*.sh /tmp
 COPY certs /tmp/certs
-
+ADD files/etc/nvidia-container-runtime/config-rootless.toml \
+    /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/config-rootless.toml
+ADD ublue-os-ucore-nvidia.spec \
+    /tmp/ublue-os-ucore-nvidia/ublue-os-ucore-nvidia.spec
 
 RUN /tmp/build-prep.sh
 
 RUN /tmp/build-kmod-nvidia.sh 470
 RUN /tmp/build-kmod-nvidia.sh 535
 RUN cd /var/cache/rpms/kmods/nvidia; ln -s 535 latest; cd /
+RUN /tmp/build-ublue-nvidia.sh
 RUN /tmp/build-kmod-zfs.sh
 
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \

--- a/Containerfile
+++ b/Containerfile
@@ -6,13 +6,15 @@ ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 FROM ${BASE_IMAGE}:${COREOS_VERSION} AS builder
 ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 
-#RUN ln -s /usr/bin/rpm-ostree /usr/bin/dnf
 COPY build*.sh /tmp
 COPY certs /tmp/certs
 
 
 RUN /tmp/build-prep.sh
 
+RUN /tmp/build-kmod-nvidia.sh 470
+RUN /tmp/build-kmod-nvidia.sh 535
+RUN cd /var/cache/rpms/kmods/nvidia; ln -s 535 latest; cd /
 RUN /tmp/build-kmod-zfs.sh
 
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+NVIDIA_MAJOR_VERSION=${1}
+
+RELEASE="$(rpm -E '%fedora.%_arch')"
+echo NVIDIA_MAJOR_VERSION=${NVIDIA_MAJOR_VERSION}
+
+cd /tmp
+
+### BUILD nvidia
+# nvidia 520.xxx and newer currently don't have a -$VERSIONxx suffix in their
+# package names
+if [[ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]]; then
+    NVIDIA_PACKAGE_NAME="nvidia"
+else
+    NVIDIA_PACKAGE_NAME="nvidia-${NVIDIA_MAJOR_VERSION}xx"
+fi
+
+dnf install -y \
+    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
+    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}
+
+# Either successfully build and install the kernel modules, or fail early with debug output
+KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-${NVIDIA_PACKAGE_NAME}" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
+NVIDIA_LIB_VERSION="$(basename "$(rpm -q "xorg-x11-drv-${NVIDIA_PACKAGE_NAME}" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
+NVIDIA_FULL_VERSION="$(rpm -q "xorg-x11-drv-${NVIDIA_PACKAGE_NAME}" --queryformat '%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}')"
+
+
+akmods --force --kernels "${KERNEL_VERSION}" --kmod "${NVIDIA_PACKAGE_NAME}"
+
+modinfo /usr/lib/modules/${KERNEL_VERSION}/extra/${NVIDIA_PACKAGE_NAME}/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz > /dev/null || \
+(cat /var/cache/akmods/${NVIDIA_PACKAGE_NAME}/${NVIDIA_AKMOD_VERSION}-for-${KERNEL_VERSION}.failed.log && exit 1)
+
+# create a directory for later copying of resulting nvidia specific artifacts
+mkdir -p /var/cache/rpms/kmods/nvidia/${NVIDIA_MAJOR_VERSION}
+
+cat <<EOF > /var/cache/rpms/kmods/nvidia/${NVIDIA_MAJOR_VERSION}/nvidia-vars
+KERNEL_VERSION=${KERNEL_VERSION}
+RELEASE=${RELEASE}
+NVIDIA_PACKAGE_NAME=${NVIDIA_PACKAGE_NAME}
+NVIDIA_MAJOR_VERSION=${NVIDIA_MAJOR_VERSION}
+NVIDIA_FULL_VERSION=${NVIDIA_FULL_VERSION}
+NVIDIA_AKMOD_VERSION=${NVIDIA_AKMOD_VERSION}
+NVIDIA_LIB_VERSION=${NVIDIA_LIB_VERSION}
+EOF
+
+mv /var/cache/akmods/${NVIDIA_PACKAGE_NAME}/*.rpm \
+   /var/cache/rpms/kmods/nvidia/${NVIDIA_MAJOR_VERSION}/
+
+# cleanup for other nvidia builds
+dnf remove -y \
+    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
+    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -39,6 +39,7 @@ rpm-ostree install \
 # stuff for akmods
 rpm-ostree install \
     akmods \
+    dnf \
     mock
 
 # stuff for dkms

--- a/build-ublue-nvidia.sh
+++ b/build-ublue-nvidia.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+### SETUP nvidia container stuffs
+
+#install -D /etc/pki/akmods/certs/public_key.der /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/public_key.der
+
+curl -L https://nvidia.github.io/nvidia-docker/rhel9.0/nvidia-docker.repo \
+    -o /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/nvidia-container-runtime.repo 
+sed -i "s@gpgcheck=0@gpgcheck=1@" /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/nvidia-container-runtime.repo
+
+curl -L https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
+    -o /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/nvidia-container.pp
+
+rpmbuild -ba \
+    --define '_topdir /tmp/ublue-os-ucore-nvidia/rpmbuild' \
+    --define '%_tmppath %{_topdir}/tmp' \
+    /tmp/ublue-os-ucore-nvidia/ublue-os-ucore-nvidia.spec
+
+mkdir -p /var/cache/rpms/kmods/nvidia
+
+mv /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/*/*.rpm \
+   /var/cache/rpms/kmods/nvidia/

--- a/files/etc/nvidia-container-runtime/config-rootless.toml
+++ b/files/etc/nvidia-container-runtime/config-rootless.toml
@@ -1,0 +1,34 @@
+disable-require = false
+#swarm-resource = "DOCKER_RESOURCE_GPU"
+#accept-nvidia-visible-devices-envvar-when-unprivileged = true
+#accept-nvidia-visible-devices-as-volume-mounts = false
+
+[nvidia-container-cli]
+#root = "/run/nvidia/driver"
+#path = "/usr/bin/nvidia-container-cli"
+environment = []
+#debug = "/var/log/nvidia-container-toolkit.log"
+#ldcache = "/etc/ld.so.cache"
+load-kmods = true
+#no-cgroups = false
+no-cgroups = true
+#user = "root:video"
+ldconfig = "@/sbin/ldconfig"
+
+[nvidia-container-runtime]
+#debug = "/var/log/nvidia-container-runtime.log"
+debug = "~/.local/nvidia-container-runtime.log"
+log-level = "info"
+
+# Specify the runtimes to consider. This list is processed in order and the PATH
+# searched for matching executables unless the entry is an absolute path.
+runtimes = [
+    "docker-runc",
+    "runc",
+]
+
+mode = "auto"
+
+    [nvidia-container-runtime.modes.csv]
+
+    mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"

--- a/ublue-os-ucore-nvidia.spec
+++ b/ublue-os-ucore-nvidia.spec
@@ -1,0 +1,47 @@
+Name:           ublue-os-ucore-nvidia
+Version:        0.1
+Release:        1%{?dist}
+Summary:        Additional files for nvidia driver support on CoreOS
+
+License:        MIT
+URL:            https://github.com/ublue-os/ucore-kmods
+
+BuildArch:      noarch
+Supplements:    mokutil policycoreutils
+
+Source0:        nvidia-container-runtime.repo
+Source1:        config-rootless.toml
+Source2:        nvidia-container.pp
+
+%description
+Adds various runtime files for nvidia support on Fedora CoreOS.
+
+%prep
+%setup -q -c -T
+
+
+%build
+install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml %{buildroot}%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
+
+%files
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+%attr(0644,root,root) %{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+%attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
+
+%changelog
+* Sat Aug 19 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.1
+First release for Fedora CoreOS based on ublue-os-nvidia-addons includes:
+- nvidia-container-runtime repo
+- nvidia-container-runtime rootless config
+- nvidia-container-runtime selinux policy file


### PR DESCRIPTION
Builds both nvidia driver versions 470 and 535 with a 'latest' symlink to version 535 allowing downstream usages to use a non-version specific path.

Note: dnf is used in the nvidia builds to allow uninstalls to prevent version collisions.

relates to [#18](https://github.com/ublue-os/ucore/issues/18)
