### PR TITLE
feat: switch to negativo17 for nvidia

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,9 +15,7 @@ ADD ublue-os-ucore-nvidia.spec \
 
 RUN /tmp/build-prep.sh
 
-RUN /tmp/build-kmod-nvidia.sh 470
-RUN /tmp/build-kmod-nvidia.sh 535
-RUN cd /var/cache/rpms/kmods/nvidia; ln -s 535 latest; cd /
+RUN /tmp/build-kmod-nvidia.sh
 RUN /tmp/build-ublue-nvidia.sh
 RUN /tmp/build-kmod-zfs.sh
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A layer for adding extra kernel modules to your Fedora CoreOS image.
 
 Feel free to PR more kmod build scripts into this repo!
 
-- nvidia - driver version 470 and 535 built from rpmfusion akmods
+- [nvidia](https://negativo17.org/nvidia-driver) - latest driver (currently version 535) built from negativo17's akmod package
 - ublue-os-ucore-nvidia - RPM with nvidia container runtime repo and selinux policy
 - [zfs](https://github.com/openzfs/zfs) - OpenZFS advanced file system and volume manager
 

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -2,55 +2,36 @@
 
 set -oeux pipefail
 
-NVIDIA_MAJOR_VERSION=${1}
-
 RELEASE="$(rpm -E '%fedora.%_arch')"
-echo NVIDIA_MAJOR_VERSION=${NVIDIA_MAJOR_VERSION}
 
 cd /tmp
 
 ### BUILD nvidia
-# nvidia 520.xxx and newer currently don't have a -$VERSIONxx suffix in their
-# package names
-if [[ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]]; then
-    NVIDIA_PACKAGE_NAME="nvidia"
-else
-    NVIDIA_PACKAGE_NAME="nvidia-${NVIDIA_MAJOR_VERSION}xx"
-fi
 
 dnf install -y \
-    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
-    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}
+    akmod-nvidia*:*.fc${RELEASE}
 
 # Either successfully build and install the kernel modules, or fail early with debug output
+rpm -qa |grep nvidia
 KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
-NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-${NVIDIA_PACKAGE_NAME}" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
-NVIDIA_LIB_VERSION="$(basename "$(rpm -q "xorg-x11-drv-${NVIDIA_PACKAGE_NAME}" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
-NVIDIA_FULL_VERSION="$(rpm -q "xorg-x11-drv-${NVIDIA_PACKAGE_NAME}" --queryformat '%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}')"
+NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
 
 
-akmods --force --kernels "${KERNEL_VERSION}" --kmod "${NVIDIA_PACKAGE_NAME}"
+akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
 
-modinfo /usr/lib/modules/${KERNEL_VERSION}/extra/${NVIDIA_PACKAGE_NAME}/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz > /dev/null || \
-(cat /var/cache/akmods/${NVIDIA_PACKAGE_NAME}/${NVIDIA_AKMOD_VERSION}-for-${KERNEL_VERSION}.failed.log && exit 1)
+modinfo /usr/lib/modules/${KERNEL_VERSION}/extra/nvidia/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz > /dev/null || \
+(cat /var/cache/akmods/nvidia/${NVIDIA_AKMOD_VERSION}-for-${KERNEL_VERSION}.failed.log && exit 1)
 
 # create a directory for later copying of resulting nvidia specific artifacts
-mkdir -p /var/cache/rpms/kmods/nvidia/${NVIDIA_MAJOR_VERSION}
+mkdir -p /var/cache/rpms/kmods/nvidia
 
-cat <<EOF > /var/cache/rpms/kmods/nvidia/${NVIDIA_MAJOR_VERSION}/nvidia-vars
+cat <<EOF > /var/cache/rpms/kmods/nvidia/nvidia-vars
 KERNEL_VERSION=${KERNEL_VERSION}
 RELEASE=${RELEASE}
-NVIDIA_PACKAGE_NAME=${NVIDIA_PACKAGE_NAME}
-NVIDIA_MAJOR_VERSION=${NVIDIA_MAJOR_VERSION}
-NVIDIA_FULL_VERSION=${NVIDIA_FULL_VERSION}
 NVIDIA_AKMOD_VERSION=${NVIDIA_AKMOD_VERSION}
-NVIDIA_LIB_VERSION=${NVIDIA_LIB_VERSION}
 EOF
+#NVIDIA_FULL_VERSION=${NVIDIA_FULL_VERSION}
+#NVIDIA_LIB_VERSION=${NVIDIA_LIB_VERSION}
 
-mv /var/cache/akmods/${NVIDIA_PACKAGE_NAME}/*.rpm \
-   /var/cache/rpms/kmods/nvidia/${NVIDIA_MAJOR_VERSION}/
-
-# cleanup for other nvidia builds
-dnf remove -y \
-    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
-    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}
+mv /var/cache/akmods/nvidia/*.rpm \
+   /var/cache/rpms/kmods/nvidia/

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -9,11 +9,9 @@ RELEASE="$(rpm -E '%fedora')"
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 
-mkdir /tmp/rpms
-curl -sL --output-dir /tmp/rpms --remote-name \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm
-curl -sL --output-dir /tmp/rpms --remote-name \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+# repo for nvidia builds
+curl -sL --output-dir /etc/yum.repos.d --remote-name \
+    https://negativo17.org/repos/fedora-nvidia.repo
 
 # enable testing repos if not enabled on testing stream
 if [[ "testing" == "${COREOS_VERSION}" ]]; then
@@ -31,7 +29,6 @@ mkdir -p /var/lib/alternatives
 
 find /tmp/
 rpm-ostree install \
-    /tmp/rpms/*.rpm \
     fedora-repos-archive
 
 


### PR DESCRIPTION
The different packaging of negativo17's nvidia allows for installing the driver without all the xorg/wayland libraries. This is desirable on our FCOS based, lightweight images.

The downside is negativo17 is not building driver 470, so we won't have that if we go with this PR.