### PR TITLE
feat: pin ZFS to 2.1.x release series

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,7 @@ RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-nvidia.sh
 RUN /tmp/build-kmod-nvidia.sh
-RUN /tmp/build-kmod-zfs.sh
+RUN ZFS_MINOR_VERSION=2.1 /tmp/build-kmod-zfs.sh
 
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feel free to PR more kmod build scripts into this repo!
 - ublue-os-ucore-nvidia - RPM with nvidia container toolkit repo and selinux policy
     - [nvidia container selinux policy](https://github.com/NVIDIA/dgx-selinux/tree/master/src/nvidia-container-selinux) - uses RHEL9 policy as the closest match
     - [nvidia-container-tookkit repo](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-yum-or-dnf) - version 1.14.2 (and newer) provide CDI for podman use of nvidia gpus
-- [zfs](https://github.com/openzfs/zfs) - OpenZFS advanced file system and volume manager
+- [zfs](https://github.com/openzfs/zfs) - OpenZFS advanced file system and volume manager *(currently pinned to 2.1 release series)*
 
 
 # Usage

--- a/build-kmod-zfs.sh
+++ b/build-kmod-zfs.sh
@@ -7,12 +7,16 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+# allow pinning to a specific release series (eg, 2.0.x or 2.1.x)
+ZFS_MINOR_VERSION="${ZFS_MINOR_VERSION:-}"
+
 cd /tmp
 
 # Use cURL to fetch the given URL, saving the response to `data.json`
 curl "https://api.github.com/repos/openzfs/zfs/releases" -o data.json
-ZFS_VERSION=$(jq -r '[ .[] | select(.prerelease==false and .draft==false) ][0].tag_name' data.json|cut -f2- -d-)
-ZFS_PREVIOUS=$(jq -r '[ .[] | select(.prerelease==false and .draft==false) ][1].tag_name' data.json|cut -f2- -d-)
+ZFS_VERSION=$(jq -r --arg ZMV "zfs-${ZFS_MINOR_VERSION}" '[ .[] | select(.prerelease==false and .draft==false) | select(.tag_name | startswith($ZMV))][0].tag_name' data.json|cut -f2- -d-)
+echo "ZFS_VERSION==$ZFS_VERSION"
+
 
 ### zfs specific build deps
 rpm-ostree install libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel python3-devel libffi-devel libcurl-devel


### PR DESCRIPTION
2 days ago ZFS released 2.2.0. The builds for 2.2.0 are "succeeding" however, the resuling kmod-zfs RPM is missing important libs and does not work at runtime.

Adding this pin to keep us on 2.1 until the matter can be resolved.

Workaround for https://github.com/ublue-os/ucore/issues/88