### PR TITLE
feat: upgrade to zfs 2.2+

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,7 @@ RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-nvidia.sh
 RUN /tmp/build-kmod-nvidia.sh
-RUN ZFS_MINOR_VERSION=2.1 /tmp/build-kmod-zfs.sh
+RUN ZFS_MINOR_VERSION=2.2 /tmp/build-kmod-zfs.sh
 
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Feel free to PR more kmod build scripts into this repo!
 - ublue-os-ucore-nvidia - RPM with nvidia container toolkit repo and selinux policy
     - [nvidia container selinux policy](https://github.com/NVIDIA/dgx-selinux/tree/master/src/nvidia-container-selinux) - uses RHEL9 policy as the closest match
     - [nvidia-container-tookkit repo](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-yum-or-dnf) - version 1.14.2 (and newer) provide CDI for podman use of nvidia gpus
-- [zfs](https://github.com/openzfs/zfs) - OpenZFS advanced file system and volume manager *(currently pinned to 2.1 release series)*
+- [zfs](https://github.com/openzfs/zfs) - OpenZFS advanced file system and volume manager *(currently pinned to 2.2 release series)*
 
 
 # Usage


### PR DESCRIPTION
This changes the ZFS version to 2.2, which as of today is 2.2.2. The 2.2.2 release fixed the file corruption issues which had been present in 2.2.0. see: https://github.com/openzfs/zfs/releases/tag/zfs-2.2.2

Note that ucore will remain on ZFS 2.2.x until this version field is updated again after ZFS 2.3 hs proven somewhat stable.

Fixes: https://github.com/ublue-os/ucore/issues/88