### PR TITLE
feat: provide package with public secure boot signing key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build-ublue
+name: build-ucore
 on:
   pull_request:
   merge_group:

--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,9 @@ ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 
 COPY build*.sh /tmp
 COPY certs /tmp/certs
+
+ADD ublue-os-ucore-addons.spec \
+        /tmp/ublue-os-ucore-addons/ublue-os-ucore-addons.spec
 ADD ublue-os-ucore-nvidia.spec \
         /tmp/ublue-os-ucore-nvidia/ublue-os-ucore-nvidia.spec
 ADD files/usr/lib/systemd/system/ublue-nvctk-cdi.service \
@@ -18,7 +21,8 @@ ADD files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset \
 
 RUN /tmp/build-prep.sh
 
-RUN /tmp/build-ublue-nvidia.sh
+RUN /tmp/build-ucore-addons.sh
+RUN /tmp/build-ucore-nvidia.sh
 RUN /tmp/build-kmod-nvidia.sh
 RUN ZFS_MINOR_VERSION=2.2 /tmp/build-kmod-zfs.sh
 

--- a/build-ucore-addons.sh
+++ b/build-ucore-addons.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+### BUILD UCORE-ADDONS RPM
+install -D /etc/pki/akmods/certs/public_key.der /tmp/ublue-os-ucore-addons/rpmbuild/SOURCES/public_key.der
+rpmbuild -ba \
+    --define '_topdir /tmp/ublue-os-ucore-addons/rpmbuild' \
+    --define '%_tmppath %{_topdir}/tmp' \
+    /tmp/ublue-os-ucore-addons/ublue-os-ucore-addons.spec
+
+mkdir -p /var/cache/rpms/kmods
+
+mv /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/*/*.rpm \
+   /var/cache/rpms/kmods/

--- a/build-ucore-nvidia.sh
+++ b/build-ucore-nvidia.sh
@@ -4,8 +4,6 @@ set -oeux pipefail
 
 ### SETUP nvidia container stuffs
 
-#install -D /etc/pki/akmods/certs/public_key.der /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/public_key.der
-
 mkdir -p /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/
 
 curl -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \

--- a/ublue-os-ucore-addons.spec
+++ b/ublue-os-ucore-addons.spec
@@ -1,0 +1,33 @@
+Name:           ublue-os-ucore-addons
+Version:        0.1
+Release:        1%{?dist}
+Summary:        Signing key for ucore kmods
+
+License:        MIT
+URL:            https://github.com/ublue-os/ucore-kmods
+
+BuildArch:      noarch
+Supplements:    mokutil policycoreutils
+
+Source0:        public_key.der
+
+%description
+Adds the signing key for importing with mokutil to enable secure boot for kernel modules.
+
+%prep
+%setup -q -c -T
+
+
+%build
+# Have different name for *.der in case kmodgenca is needed for creating more keys
+install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der            %{buildroot}%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+
+%files
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+%attr(0644,root,root) %{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+
+%changelog
+* Sat Dec 30 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.1
+- Add key for enrolling ucore kernel modules for secure boot


### PR DESCRIPTION
This provides the kmod secure boot signing public key in an RPM which can then be installed by the ucore image builder.

The nvidia kmod has been signed by this key for some time, but we had not yet provided the pub key.

Related: https://github.com/ublue-os/ucore/issues/82