### PR TITLE
feat: sign zfs kmods

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,7 @@ ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 
 COPY build*.sh /tmp
 COPY certs /tmp/certs
+COPY zfs-kmod-spec-in.patch /tmp
 
 ADD ublue-os-ucore-addons.spec \
         /tmp/ublue-os-ucore-addons/ublue-os-ucore-addons.spec

--- a/build-kmod-zfs.sh
+++ b/build-kmod-zfs.sh
@@ -27,11 +27,12 @@ echo "getting zfs-${ZFS_VERSION}.tar.gz"
 curl -L -O https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz
 tar xzf zfs-${ZFS_VERSION}.tar.gz
 
+patch  -b -uN -i zfs-kmod-spec-in.patch zfs-${ZFS_VERSION}/rpm/generic/zfs-kmod.spec.in
 cd /tmp/zfs-${ZFS_VERSION}
 ./configure \
         -with-linux=/usr/src/kernels/${KERNEL}/ \
         -with-linux-obj=/usr/src/kernels/${KERNEL}/ \
-    && make -j 1 rpm-utils rpm-kmod \
+    && make -j $(nproc) rpm-utils rpm-kmod \
     || (cat config.log && exit 1)
 
 

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -5,6 +5,7 @@ set -oeux pipefail
 
 ### PREPARE REPOS
 ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
@@ -56,6 +57,9 @@ fi
 
 install -Dm644 /tmp/certs/public_key.der   /etc/pki/akmods/certs/public_key.der
 install -Dm644 /tmp/certs/private_key.priv /etc/pki/akmods/private/private_key.priv
+
+install -Dm644 /tmp/certs/public_key.der /lib/modules/${KERNEL}/build/certs/signing_key.x509
+install -Dm644 /tmp/certs/private_key.priv /lib/modules/${KERNEL}/build/certs/signing_key.pem
 
 # protect against incorrect permissions in tmp dirs which can break akmods builds
 chmod 1777 /tmp /var/tmp

--- a/zfs-kmod-spec-in.patch
+++ b/zfs-kmod-spec-in.patch
@@ -1,0 +1,33 @@
+--- rpm/generic/zfs-kmod.spec.in	2023-11-30 23:48:38.955131592 +0000
++++ ../zfs-kmod.spec.in-sign	2024-01-06 19:14:10.619938449 +0000
+@@ -150,6 +150,30 @@
+ done
+ 
+ 
++# Module signing (modsign)
++#
++# This must be run _after_ find-debuginfo.sh runs, otherwise that will strip
++# the signature off of the modules.
++# (Based on Fedora's kernel.spec workaround)
++%define __modsign_install_post \
++  sign_pem="%{ksrc}certs/signing_key.pem"; \
++  sign_x509="%{ksrc}certs/signing_key.x509"; \
++  if [ -f "${sign_x509}" ]\
++  then \
++    echo "Signing kernel modules ..."; \
++    for kmod in $(find ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/*/extra/zfs/ -name \*.ko); do \
++      %{ksrc}scripts/sign-file sha256 ${sign_pem} ${sign_x509} ${kmod}; \
++    done \
++  fi \
++%{nil}
++
++# hack to ensure singing happens after find-debuginfo.sh runs
++%define __spec_install_post \
++  %{?__debug_package:%{__debug_install_post}}\
++  %{__arch_install_post}\
++  %{__os_install_post}\
++  %{__modsign_install_post}
++
+ %install
+ rm -rf ${RPM_BUILD_ROOT}
+ 


### PR DESCRIPTION
Install a copy of the akmod signing keys to the normal kernel module signing location:
https://www.kernel.org/doc/html/v4.15/admin-guide/module-signing.html

This should be enough to sign the modules, and they do get signed, but the rpm build process strips the resulting binaries, thus removing the signatures.

So... Use a patch to the generic/kmod-zfs spec file to sign the kmods after build and strip is complete but before bundling into the RPM.

Fixes: [#16](https://github.com/ublue-os/ucore/issues/16)